### PR TITLE
Support multiple cve-ids for `id` option

### DIFF
--- a/runner/types.go
+++ b/runner/types.go
@@ -102,3 +102,7 @@ type OutputShodanData struct {
 type ErrorMessage struct {
 	Message string `json:"message"`
 }
+
+type CVEIdList struct {
+	Cves []string `json:"cves"`
+}


### PR DESCRIPTION
- closes #37 

__Test:__
```console
➜ cat cve-ids.txt         
CVE-1999-1197
CVE-1999-1115
CVE-2005-0043
CVE-1999-1258
CVE-1999-1438
➜ ./cvemap -id cve-ids.txt -silent
╭───────────────┬──────┬──────────┬─────────┬──────────────────┬───────┬──────────╮
│ ID            │ CVSS │ SEVERITY │ EPSS    │ PRODUCT          │ AGE   │ TEMPLATE │
├───────────────┼──────┼──────────┼─────────┼──────────────────┼───────┼──────────┤
│ CVE-1999-1115 │ 7.2  │ HIGH     │ 0.00061 │ apollo_domain_os │ 12075 │ ❌       │
│ CVE-1999-1197 │ 7.2  │ HIGH     │ 0.0006  │ sunos            │ 12086 │ ❌       │
│ CVE-1999-1258 │ 5    │ MEDIUM   │ 0.00256 │ sunos            │ 12060 │ ❌       │
│ CVE-1999-1438 │ 7.2  │ HIGH     │ 0.0006  │ sunos            │ 12022 │ ❌       │
│ CVE-2005-0043 │ 7.5  │ HIGH     │ 0.18629 │ itunes           │ 6839  │ ❌       │
╰───────────────┴──────┴──────────┴─────────┴──────────────────┴───────┴──────────╯
```