### PR TITLE
Allow auth option to parse string input as api key

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -3,7 +3,7 @@ package runner
 import "github.com/projectdiscovery/goflags"
 
 type Options struct {
-	PdcpAuth  bool
+	PdcpAuth  string
 	CveIds    goflags.StringSlice
 	CweIds    goflags.StringSlice
 	Vendor    goflags.StringSlice

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -165,6 +165,13 @@ func ParseOptions() *Options {
 		AuthWithPDCP()
 	} else if len(options.PdcpAuth) == 36 {
 		PDCPApiKey = options.PdcpAuth
+		ph := pdcp.PDCPCredHandler{}
+		if _, err := ph.GetCreds(); err == pdcp.ErrNoCreds {
+			apiServer := env.GetEnvOrDefault("PDCP_API_SERVER", pdcp.DefaultApiServer)
+			if validatedCreds, err := ph.ValidateAPIKey(PDCPApiKey, apiServer, "cvemap"); err == nil {
+				_ = ph.SaveCreds(validatedCreds)
+			}
+		}
 	}
 
 	if options.Limit > maxLimit {


### PR DESCRIPTION
```console
 ✗ go run . -auth


   ______   _____  ____ ___  ____  ____
  / ___/ | / / _ \/ __ \__ \/ __ \/ __ \
 / /__ | |/ /  __/ / / / / / /_/ / /_/ /
 \___/ |___/\___/_/ /_/ /_/\__,_/ .___/ 
                               /_/
                                          

                projectdiscovery.io

[INF] Get your free api key by signing up at https://cloud.projectdiscovery.io
[*] Enter PDCP API Key (exit to abort): 

✗ go run . -auth=xxx.. -l 5


   ______   _____  ____ ___  ____  ____
  / ___/ | / / _ \/ __ \__ \/ __ \/ __ \
 / /__ | |/ /  __/ / / / / / /_/ / /_/ /
 \___/ |___/\___/_/ /_/ /_/\__,_/ .___/ 
                               /_/
                                          

                projectdiscovery.io

[INF] Current cvemap version v0.0.4 (latest)
╭────────────────┬──────┬──────────┬─────────┬────────────────┬─────┬──────────╮
│ ID             │ CVSS │ SEVERITY │ EPSS    │ PRODUCT        │ AGE │ TEMPLATE │
├────────────────┼──────┼──────────┼─────────┼────────────────┼─────┼──────────┤
│ CVE-2024-23222 │ 8.8  │ HIGH     │ 0.00179 │ ipados         │ 20  │ ❌       │
│ CVE-2024-21893 │ 8.2  │ HIGH     │ 0.96249 │ connect_secure │ 11  │ ✅       │
│ CVE-2024-21887 │ 9.1  │ CRITICAL │ 0.97302 │ connect_secure │ 30  │ ✅       │
│ CVE-2024-21762 │ 9.8  │ CRITICAL │ 0.01179 │                │ 2   │ ❌       │
│ CVE-2024-0519  │ 8.8  │ HIGH     │ 0.00179 │ chrome         │ 26  │ ❌       │
╰────────────────┴──────┴──────────┴─────────┴────────────────┴─────┴──────────╯
```