### PR TITLE
Fix issue #89 - Cannot run CVEMap inside a CI/CD Pipeline

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -234,7 +234,7 @@ func (r *Runner) Run() {
 		}
 	}
 
-	if r.Options.CveIds[0] == "" {
+	if len(r.Options.CveIds) > 0 && r.Options.CveIds[0] == "" {
 		r.Options.CveIds = []string{} 
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -234,6 +234,10 @@ func (r *Runner) Run() {
 		}
 	}
 
+	if r.Options.CveIds[0] == "" {
+		r.Options.CveIds = []string{} 
+	}
+
 	// on default, enable kev
 	if isDefaultRun(r.Options) {
 		r.Options.Kev = "true"


### PR DESCRIPTION
(see issue [#89](https://github.com/projectdiscovery/cvemap/issues/89) for context) 

The cause of the issue is the content r.Options.CveIds inside the runner.go file (func (r *Runner) Run()) => In my gitlab environment during the execution somehow it added "" to the content of r.Options.CveIds, I proposed a pull request able to fix the issue. It is to be considered a temporary fix and I suggest further investigations regarding the sanitization of the input