### PR TITLE
Add health check option

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -41,4 +41,5 @@ type Options struct {
 	Silent             bool
 	Verbose            bool
 	Debug              bool
+	HealthCheck        bool
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -146,6 +146,7 @@ func ParseOptions() *Options {
 		flagset.BoolVar(&options.Silent, "silent", false, "Silent"),
 		flagset.BoolVar(&options.Verbose, "verbose", false, "Verbose"),
 		flagset.BoolVar(&options.Debug, "debug", false, "Debug"),
+		flagset.BoolVarP(&options.HealthCheck, "health-check", "hc", false, "run diagnostic check up"),
 	)
 
 	if err := flagset.Parse(); err != nil {
@@ -157,6 +158,12 @@ func ParseOptions() *Options {
 	}
 	if options.Version {
 		gologger.Info().Msgf("Current Version: %s\n", Version)
+		os.Exit(0)
+	}
+
+	if options.HealthCheck {
+		showBanner()
+		gologger.Print().Msgf("%s\n", DoHealthCheck(options))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
```console
✗ go run . -hc


   ______   _____  ____ ___  ____  ____
  / ___/ | / / _ \/ __ \__ \/ __ \/ __ \
 / /__ | |/ /  __/ / / / / / /_/ / /_/ /
 \___/ |___/\___/_/ /_/ /_/\__,_/ .___/ 
                               /_/
                                          

                projectdiscovery.io

Version: v0.0.5
Operating System: darwin
Architecture: arm64
Go Version: go1.21.3
Compiler: gc
IPv4 connectivity to cve.projectdiscovery.io:443 => Ok
IPv4 UDP connectivity to cve.projectdiscovery.io:53 => Ok
```