### PR TITLE
Add new flag to display overview of CVEs

### DIFF
--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	Search             string
 	RemotlyExploitable string
 	EnablePageKeys     bool
+	Explain            bool
 	Json               bool
 	Limit              int
 	Offset             int

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -553,7 +553,9 @@ func outputCveExplained(cves []types.CVEData) {
 			gologger.Silent().Msgf("Severity: %s", cve.Severity)
 			if len(cve.Weaknesses) != 0 {
 					for _,cwe := range cve.Weaknesses {
-							gologger.Silent().Msgf("CWE Info: %s(%s)", cwe.CWEID, cwe.CWEName)
+							if strings.Compare(cwe.CVEID, "NVD-CWE-noinfo") {
+								gologger.Silent().Msgf("CWE Info: %s (%s)", cwe.CWEID, cwe.CWEName)
+							}
 					}
 			}
 			gologger.Silent().Msgf("Age: %d", cve.AgeInDays)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -553,7 +553,7 @@ func outputCveExplained(cves []types.CVEData) {
 			gologger.Silent().Msgf("Severity: %s", cve.Severity)
 			if len(cve.Weaknesses) != 0 {
 					for _,cwe := range cve.Weaknesses {
-							if strings.Compare(cwe.CVEID, "NVD-CWE-noinfo") {
+							if strings.Compare(cwe.CWEID, "NVD-CWE-noinfo") != 0 {
 								gologger.Silent().Msgf("CWE Info: %s (%s)", cwe.CWEID, cwe.CWEName)
 							}
 					}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -562,7 +562,7 @@ func outputCveExplained(cves []types.CVEData) {
 			gologger.Silent().Msgf("Vulnerability Status: %s", cve.VulnStatus)
 			gologger.Silent().Msgf("Exploited Remotely: %t", cve.IsRemote)
 			gologger.Silent().Msgf("POC Available: %t", cve.IsPoc)
-			if cve.IsPoc == true {
+			if cve.IsPoc {
 					gologger.Silent().Msgf("POC(s):")
 					for _,poc := range cve.Poc {
 							gologger.Silent().Msgf("\t%s - %s", poc.Source, poc.URL)
@@ -574,7 +574,7 @@ func outputCveExplained(cves []types.CVEData) {
 							gologger.Silent().Msgf("\t- %s", patch)
 					}
 			}
-			if cve.IsTemplate == true {
+			if cve.IsTemplate {
 					gologger.Silent().Msgf("Nuclei Template:")
 					gologger.Silent().Msgf("\tPath: %s", cve.NucleiTemplates.TemplatePath)
 					gologger.Silent().Msgf("\tURL: %s", cve.NucleiTemplates.TemplateURL)


### PR DESCRIPTION
# Description
Adds `-explain` flag to cvemap. This flag will display general information on the CVEs returned from a search. It is most helpful when querying a small amount of CVEs, JSON is recommended for larger outputs. Flag can be combined with `-silent` to omit banner if needed.

# Reason for Addition
While it is possible to retrieve all available CVE data in the form of JSON, it's convenient to be able to view general data (description, cwe info, POC and reference links, patches,  etc.) in an easy-to-read fashion and without having to parse data outside the tool. This feature merely adds an additional option for viewing data pertaining to the CVEs returned from a search.

# Usage
```
./cvemap -limit 1 -explain


   ______   _____  ____ ___  ____  ____
  / ___/ | / / _ \/ __ \__ \/ __ \/ __ \
 / /__ | |/ /  __/ / / / / / /_/ / /_/ /
 \___/ |___/\___/_/ /_/ /_/\__,_/ .___/
                               /_/


                projectdiscovery.io

[INF] Current cvemap version v0.0.7 (latest)
CVE ID: CVE-2024-9680
Description: An attacker was able to achieve code execution in the content process by exploiting a use-after-free in Animation timelines. We have had reports of this vulnerability being exploited in the wild. This vulnerability affects Firefox < 131.0.2, Firefox ESR < 128.3.1, Firefox ESR < 115.16.1, Thunderbird < 131.0.1, Thunderbird < 128.3.1, and Thunderbird < 115.16.0.
CVSS Score: 9.8
Severity: critical
CWE Info: CWE-416(Use After Free)
Age: 89
Vulnerability Status: confirmed
Exploited Remotely: true
POC Available: true
POC(s):
        gh-nomi-sec - https://github.com/PraiseImafidon/Version_Vulnerability_Scanner
        gh-nomi-sec - https://github.com/tdonaworth/Firefox-CVE-2024-9680
Available Patch(es):
        - https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2024-49039
Reference(s):
        - https://bugzilla.mozilla.org/show_bug.cgi?id=1923344
        - https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=281992
        - https://lists.debian.org/debian-lts-announce/2024/10/msg00005.html
        - https://github.com/PraiseImafidon/Version_Vulnerability_Scanner
        - https://github.com/fkie-cad/nvd-json-data-feeds
        - https://github.com/nomi-sec/PoC-in-GitHub
        - https://github.com/tdonaworth/Firefox-CVE-2024-9680

For all CVE data, output to JSON using -j/-json
```