### PR TITLE
[feat] Add a flag for CSV output

### DIFF
--- a/cmd/vulnx/clis/common.go
+++ b/cmd/vulnx/clis/common.go
@@ -516,8 +516,8 @@ func runIDCommandWithIDs(cveIDs []string) error {
 	// Use the global vulnxClient
 	handler := id.NewHandler(vulnxClient)
 
-	// Handle JSON output for multiple IDs
-	if jsonOutput || outputFile != "" {
+	// Handle JSON/CSV output for multiple IDs
+	if jsonOutput || outputFile != "" || csvFile != "" {
 		var allVulns []*vulnx.Vulnerability
 		for _, vulnID := range cveIDs {
 			vuln, err := handler.Get(vulnID)
@@ -534,6 +534,38 @@ func runIDCommandWithIDs(cveIDs []string) error {
 
 		if len(allVulns) == 0 {
 			gologger.Fatal().Msg("No vulnerabilities were successfully retrieved")
+		}
+
+		// Handle CSV output
+		if csvFile != "" {
+			csvEntries := make([]*renderer.Entry, 0, len(allVulns))
+			for _, vuln := range allVulns {
+				entry := renderer.FromVulnerability(vuln)
+				if entry != nil {
+					csvEntries = append(csvEntries, entry)
+				}
+			}
+			csvBytes, err := renderer.RenderCSV(csvEntries)
+			if err != nil {
+				gologger.Fatal().Msgf("Failed to render CSV: %s", err)
+			}
+			if _, err := os.Stat(csvFile); err == nil {
+				gologger.Fatal().Msgf("Output file already exists: %s", csvFile)
+			}
+			f, err := os.OpenFile(csvFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+			if err != nil {
+				gologger.Fatal().Msgf("Failed to create output file: %s", err)
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					gologger.Error().Msgf("Failed to close output file: %s", err)
+				}
+			}()
+			if _, err := f.Write(csvBytes); err != nil {
+				gologger.Fatal().Msgf("Failed to write to output file: %s", err)
+			}
+			gologger.Info().Msgf("Wrote %d vulnerability(s) to file: %s", len(allVulns), csvFile)
+			return nil
 		}
 
 		// Marshal single item or array based on input

--- a/cmd/vulnx/clis/common.go
+++ b/cmd/vulnx/clis/common.go
@@ -61,6 +61,9 @@ var (
 	// Add global no-color flag
 	noColor bool
 
+	// Add global csv output flag
+	csvFile string
+	
 	// Global disable update check flag
 	globalDisableUpdateCheck bool
 
@@ -185,6 +188,9 @@ func init() {
 
 	// Add persistent no-color flag
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
+
+	// Add persistent csv output flag
+	rootCmd.PersistentFlags().StringVar(&csvFile, "csv", "", "write output to CSV file (error if file exists)")
 
 	// Add persistent disable update check flag
 	rootCmd.PersistentFlags().BoolVar(&globalDisableUpdateCheck, "disable-update-check", false, "disable automatic vulnx update check")

--- a/cmd/vulnx/clis/common.go
+++ b/cmd/vulnx/clis/common.go
@@ -96,6 +96,10 @@ var (
 					showVersionInfo()
 				}
 			}
+			if err := validateOutputFlags(); err != nil {
+				return err
+			}
+
 			err := ensureVulnxClientInitialized(cmd)
 			if err != nil {
 				return err
@@ -499,6 +503,32 @@ func removeDuplicateStrings(ids []string) []string {
 	}
 
 	return result
+}
+
+// validateOutputFlags enforces mutual exclusivity and extension rules for the
+// three output-mode flags (--json, --output, --csv). Called from PersistentPreRunE
+// so it applies uniformly to every subcommand, including the stdin auto-detect path.
+func validateOutputFlags() error {
+	outputModes := 0
+	if jsonOutput {
+		outputModes++
+	}
+	if outputFile != "" {
+		outputModes++
+	}
+	if csvFile != "" {
+		outputModes++
+	}
+	if outputModes > 1 {
+		return fmt.Errorf("--json, --output, and --csv are mutually exclusive; specify at most one")
+	}
+	if outputFile != "" && !strings.HasSuffix(outputFile, ".json") {
+		return fmt.Errorf("--output file must have a .json extension")
+	}
+	if csvFile != "" && !strings.HasSuffix(csvFile, ".csv") {
+		return fmt.Errorf("--csv file must have a .csv extension")
+	}
+	return nil
 }
 
 func executeIDWithIDs(cveIDs []string) error {

--- a/cmd/vulnx/clis/common.go
+++ b/cmd/vulnx/clis/common.go
@@ -505,6 +505,32 @@ func removeDuplicateStrings(ids []string) []string {
 	return result
 }
 
+// csvRequiredFields are the API field names needed to populate every CSV column.
+var csvRequiredFields = []string{
+	"doc_id", "name", "severity", "cvss_score", "epss_score",
+	"is_kev", "is_template", "poc_count", "h1",
+	"is_patch_available", "age_in_days", "affected_products", "tags",
+}
+
+// mergeFields returns base with any elements from extra appended that are not already present.
+func mergeFields(base, extra []string) []string {
+	if len(base) == 0 {
+		return base // no field restriction at all — API returns everything
+	}
+	seen := make(map[string]bool, len(base))
+	for _, f := range base {
+		seen[f] = true
+	}
+	result := make([]string, len(base))
+	copy(result, base)
+	for _, f := range extra {
+		if !seen[f] {
+			result = append(result, f)
+		}
+	}
+	return result
+}
+
 // validateOutputFlags enforces mutual exclusivity and extension rules for the
 // three output-mode flags (--json, --output, --csv). Called from PersistentPreRunE
 // so it applies uniformly to every subcommand, including the stdin auto-detect path.

--- a/cmd/vulnx/clis/id.go
+++ b/cmd/vulnx/clis/id.go
@@ -106,7 +106,10 @@ vulnx id --no-color CVE-2024-1234
 			if len(vulnIDs) == 0 {
 				gologger.Fatal().Msg("No vulnerability IDs provided. Use command line arguments, --file, or pipe IDs via stdin")
 			}
-
+			
+			if csvFile != "" && !strings.HasSuffix(csvFile, ".csv") {
+				gologger.Fatal().Msg("csv output file must have .csv extension")
+			}
 			// Remove duplicates and validate IDs
 			vulnIDs = removeDuplicates(vulnIDs)
 			for _, vulnID := range vulnIDs {

--- a/cmd/vulnx/clis/id.go
+++ b/cmd/vulnx/clis/id.go
@@ -124,7 +124,7 @@ vulnx id --no-color CVE-2024-1234
 			handler := id.NewHandler(vulnxClient)
 
 			// Handle JSON output for multiple IDs
-			if jsonOutput || outputFile != "" {
+			if jsonOutput || outputFile != "" || csvFile != "" {
 				var allVulns []*vulnx.Vulnerability
 				for _, vulnID := range vulnIDs {
 					vuln, err := handler.Get(vulnID)
@@ -144,6 +144,39 @@ vulnx id --no-color CVE-2024-1234
 
 				if len(allVulns) == 0 {
 					gologger.Fatal().Msg("No vulnerabilities were successfully retrieved")
+				}
+
+				// Handle CSV output
+				if csvFile != "" {
+					csvEntries := make([]*renderer.Entry, 0, len(allVulns))
+					for _, vuln := range allVulns {
+						entry := renderer.FromVulnerability(vuln)
+						if entry != nil {
+							csvEntries = append(csvEntries, entry)
+						}
+					}
+					csvBytes, err := renderer.RenderCSV(csvEntries)
+					if err != nil {
+						gologger.Fatal().Msgf("Failed to render CSV: %s", err)
+					}
+					// Check if file exists
+					if _, err := os.Stat(csvFile); err == nil {
+						gologger.Fatal().Msgf("Output file already exists: %s", csvFile)
+					}
+					f, err := os.OpenFile(csvFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+					if err != nil {
+						gologger.Fatal().Msgf("Failed to create output file: %s", err)
+					}
+					defer func() {
+						if err := f.Close(); err != nil {
+							gologger.Error().Msgf("Failed to close output file: %s", err)
+						}
+					}()
+					if _, err := f.Write(csvBytes); err != nil {
+						gologger.Fatal().Msgf("Failed to write to output file: %s", err)
+					}
+					gologger.Info().Msgf("Wrote %d vulnerability(s) to file: %s", len(allVulns), csvFile)
+					return
 				}
 
 				// Marshal single item or array based on input

--- a/cmd/vulnx/clis/search.go
+++ b/cmd/vulnx/clis/search.go
@@ -616,20 +616,6 @@ func validateSearchInputs() error {
 		return fmt.Errorf("facet-size must be between 1 and 1000")
 	}
 
-	// Validate output file path if specified
-	if outputFile != "" {
-		if !strings.HasSuffix(outputFile, ".json") {
-			return fmt.Errorf("output file must have .json extension")
-		}
-	}
-
-	// Validate csv output file path if specified
-	if csvFile != "" {
-		if !strings.HasSuffix(csvFile, ".csv") {
-			return fmt.Errorf("csv output file must have .csv extension")
-		}
-	}
-
 	return nil
 }
 

--- a/cmd/vulnx/clis/search.go
+++ b/cmd/vulnx/clis/search.go
@@ -243,6 +243,39 @@ vulnx search --term-facets tags=10,severity=4 "is_remote:true"
 				return
 			}
 
+			// Handle CSV output
+			if csvFile != "" {
+				csvEntries := make([]*renderer.Entry, 0, len(resp.Results))
+				for _, vuln := range resp.Results {
+					entry := renderer.FromVulnerability(&vuln)
+					if entry != nil {
+						csvEntries = append(csvEntries, entry)
+					}
+				}
+				csvBytes, err := renderer.RenderCSV(csvEntries)
+				if err != nil {
+					gologger.Fatal().Msgf("Failed to render CSV: %s", err)
+				}
+				// Check if file exists
+				if _, err := os.Stat(csvFile); err == nil {
+					gologger.Fatal().Msgf("Output file already exists: %s", csvFile)
+				}
+				f, err := os.OpenFile(csvFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+				if err != nil {
+					gologger.Fatal().Msgf("Failed to create output file: %s", err)
+				}
+				defer func() {
+					if err := f.Close(); err != nil {
+						gologger.Error().Msgf("Failed to close output file: %s", err)
+					}
+				}()
+				if _, err := f.Write(csvBytes); err != nil {
+					gologger.Fatal().Msgf("Failed to write to output file: %s", err)
+				}
+				gologger.Info().Msgf("Wrote output to file: %s", csvFile)
+				return
+			}
+
 			// Default CLI renderer format
 			layout, err := renderer.ParseLayout([]byte(defaultLayoutJSON))
 			if err != nil {
@@ -587,6 +620,13 @@ func validateSearchInputs() error {
 	if outputFile != "" {
 		if !strings.HasSuffix(outputFile, ".json") {
 			return fmt.Errorf("output file must have .json extension")
+		}
+	}
+
+	// Validate csv output file path if specified
+	if csvFile != "" {
+		if !strings.HasSuffix(csvFile, ".csv") {
+			return fmt.Errorf("csv output file must have .csv extension")
 		}
 	}
 

--- a/cmd/vulnx/clis/search.go
+++ b/cmd/vulnx/clis/search.go
@@ -153,6 +153,11 @@ vulnx search --term-facets tags=10,severity=4 "is_remote:true"
 			if len(searchFields) > 0 {
 				params.Fields = searchFields
 			}
+			// When writing CSV, ensure all columns the exporter needs are present
+			// even if the user narrowed the response via --fields.
+			if csvFile != "" {
+				params.Fields = mergeFields(params.Fields, csvRequiredFields)
+			}
 			if len(searchTermFacets) > 0 {
 				params.TermFacets = searchTermFacets
 				for i, facet := range params.TermFacets {

--- a/pkg/tools/renderer/helpers.go
+++ b/pkg/tools/renderer/helpers.go
@@ -65,6 +65,32 @@ func truncateProductName(productName string, maxLength int) string {
 	return productName[:maxLength-3] + "..."
 }
 
+// distinctVendors returns untruncated distinct vendor names, suitable for data-export formats.
+func distinctVendors(products []*vulnx.ProductInfo) []string {
+	seen := make(map[string]bool)
+	var vendors []string
+	for _, p := range products {
+		if p != nil && p.Vendor != "" && !seen[p.Vendor] {
+			seen[p.Vendor] = true
+			vendors = append(vendors, p.Vendor)
+		}
+	}
+	return vendors
+}
+
+// distinctProducts returns untruncated distinct product names, suitable for data-export formats.
+func distinctProducts(products []*vulnx.ProductInfo) []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, p := range products {
+		if p != nil && p.Product != "" && !seen[p.Product] {
+			seen[p.Product] = true
+			names = append(names, p.Product)
+		}
+	}
+	return names
+}
+
 // extractDistinctVendors extracts distinct vendors from a slice of ProductInfo
 func extractDistinctVendors(products []*vulnx.ProductInfo) []string {
 	seen := make(map[string]bool)

--- a/pkg/tools/renderer/renderer.go
+++ b/pkg/tools/renderer/renderer.go
@@ -31,8 +31,8 @@ func RenderCSV(entries []*Entry) ([]byte, error) {
 	}
 
 	for _, e := range entries {
-		vendors := extractDistinctVendors(e.AffectedProducts)
-		products := extractDistinctProducts(e.AffectedProducts)
+		vendors := distinctVendors(e.AffectedProducts)
+		products := distinctProducts(e.AffectedProducts)
 		hackerone := e.H1 != nil && e.H1.Reports > 0
 
 		row := []string{

--- a/pkg/tools/renderer/renderer.go
+++ b/pkg/tools/renderer/renderer.go
@@ -1,6 +1,8 @@
 package renderer
 
 import (
+	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -10,6 +12,52 @@ import (
 // Render generates formatted output for vulnerability entries using the provided layout
 func Render(entries []*Entry, layout []LayoutLine, totalResults, shownResults int) string {
 	return RenderWithColors(entries, layout, totalResults, shownResults, DefaultColorConfig())
+}
+
+// RenderCSV generates a CSV representation of vulnerability entries.
+// Columns: id, severity, cvss_score, epss_score, is_kev, is_template, poc_count,
+// hackerone, is_patch_available, age_in_days, vendors, products, tags, title
+func RenderCSV(entries []*Entry) ([]byte, error) {
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+
+	header := []string{
+		"id", "severity", "cvss_score", "epss_score",
+		"is_kev", "is_template", "poc_count", "hackerone",
+		"is_patch_available", "age_in_days", "vendors", "products", "tags", "title",
+	}
+	if err := w.Write(header); err != nil {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		vendors := extractDistinctVendors(e.AffectedProducts)
+		products := extractDistinctProducts(e.AffectedProducts)
+		hackerone := e.H1 != nil && e.H1.Reports > 0
+
+		row := []string{
+			e.DocID,
+			e.Severity,
+			strconv.FormatFloat(e.CvssScore, 'f', -1, 64),
+			strconv.FormatFloat(e.EpssScore, 'f', -1, 64),
+			strconv.FormatBool(e.IsKev),
+			strconv.FormatBool(e.IsTemplate),
+			strconv.Itoa(e.PocCount),
+			strconv.FormatBool(hackerone),
+			strconv.FormatBool(e.IsPatchAvailable),
+			strconv.Itoa(e.AgeInDays),
+			strings.Join(vendors, ";"),
+			strings.Join(products, ";"),
+			strings.Join(e.Tags, ";"),
+			e.Name,
+		}
+		if err := w.Write(row); err != nil {
+			return nil, err
+		}
+	}
+
+	w.Flush()
+	return buf.Bytes(), w.Error()
 }
 
 // RenderDetailed generates detailed formatted output for a single vulnerability


### PR DESCRIPTION
# Description

A new `--csv`' flag has been introduced that allows users to export vulnerability results directly to a CSV file from both the search and ID commands. If the target file already exists, an error is returned, in line with the behaviour of the `--output` flag. It serialises each vulnerability Entry into a row with the following columns:

`id, severity, cvss_score, epss_score, is_kev, is_template,
poc_count, hackerone, is_patch_available, age_in_days,
vendors, products, tags, title`

The flag also validates that the provided path ends with .csv and refuses to overwrite an existing file.

# Examples
- Export search results to CSV: `vulnx search "is_remote:true" --csv results.csv`
- Export a specific CVE to CSV: `vulnx id CVE-2024-1234 --csv output.csv`
- Export multiple CVEs to a single CSV: `vulnx id CVE-2024-1234 CVE-2024-5678 --csv report.csv`






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional CSV export path alongside existing JSON/file output, with simple extension and overwrite protections.
> 
> **Overview**
> Adds a global `--csv` flag to export vulnerability results to a CSV file for both `vulnx search` and `vulnx id`, refusing to overwrite existing files and validating the `.csv` extension.
> 
> Introduces `renderer.RenderCSV` to serialize vulnerability `Entry` data into a fixed set of CSV columns (including scores, flags, vendors/products/tags, and title), and wires the commands to render and write this output when `--csv` is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e97f424abdb497ff2af4dedc0fd1136d01d23b40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent --csv option to export command results to CSV; writes CSV, errors if target file exists, and logs the written count.

* **Bug Fixes / Validation**
  * Output flags (--json, --output, --csv) are now mutually exclusive and file extensions for outputs are validated. Search no longer requires a .json suffix for its output file.

* **Refactor**
  * Added CSV rendering and helper logic to build rows and deduplicate vendor/product values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->