### PR TITLE
fix: inject version via ldflags at build time (fixes #460)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 VERSION_LDFLAG := -X github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis.Version=$(VERSION)
 
 ifneq ($(shell go env GOOS),darwin)
-LDFLAGS := -extldflags "-static"
+LDFLAGS += -extldflags "-static"
 endif
 
 all: build

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,17 @@ GOFLAGS := -v
 # This should be disabled if the binary uses pprof
 LDFLAGS := -s -w
 
+# Determine the version from git tags (falls back to "dev" if not in a tag)
+VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+VERSION_LDFLAG := -X github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis.Version=$(VERSION)
+
 ifneq ($(shell go env GOOS),darwin)
 LDFLAGS := -extldflags "-static"
 endif
 
 all: build
 build:
-	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS)' -o "vulnx" cmd/vulnx/main.go
+	$(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS) $(VERSION_LDFLAG)' -o "vulnx" cmd/vulnx/main.go
 integration:
 	cd cmd/integration-test; bash run.sh
 tidy:


### PR DESCRIPTION
## Summary

Fixes #460

### Problem
When compiling vulnx from source using `make build` (or any custom `go build` command), the resulting binary always reports version `v1.0.0` because the `VERSION` ldflags injection was missing from the Makefile.

This affects Linux distributor packagers (Blackarch, Pentoo, Arch, etc.) who build from source without running goreleaser.

### Root cause
The `.goreleaser.yml` correctly injects the version:
```yaml
ldflags:
  - -s -w -X github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis.Version={{.Version}}
```

But the `Makefile` `build` target was missing this flag:
```makefile
# Before (missing version injection):
  -ldflags '' -o "vulnx" cmd/vulnx/main.go
```

### Fix
Derive the version from `git describe --tags --abbrev=0` and pass it as an ldflag, with `dev` as a safe fallback:

```makefile
VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
VERSION_LDFLAG := -X github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis.Version=$(VERSION)

build:
    $(GOBUILD) $(GOFLAGS) -ldflags '$(LDFLAGS) $(VERSION_LDFLAG)' -o "vulnx" cmd/vulnx/main.go
```

Packagers can also override via: `make build VERSION=v2.1.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build process to automatically embed a version identifier into the produced binary at build time, derived from the latest git tag, with a safe default when no tags are available. This ensures the app reports the correct build/version information for released builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->