### PR TITLE
fix: remove unsupported search filter flags (#476)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -194,41 +194,28 @@ vulnx search "is_oss:true && severity:high && cve_created_at:2024"
 
 ## Advanced Filter Usage
 
-### Exclusion Filters
+### Product and Vendor Filtering
 
 ```bash
-# Exclude specific products while searching
-vulnx search --exclude-product apache,nginx "web server"
-vulnx search --exclude-vendor microsoft,oracle "database"
-vulnx search --exclude-severity low,medium "remote"
-
-```
-
-### CPE-Based Filtering
-
-```bash
-# Precise product matching with CPE
-vulnx search --cpe "cpe:2.3:a:apache:*" "cve_created_at:2024"
-vulnx search --cpe "cpe:2.3:o:microsoft:windows:*" "severity:critical"
-vulnx search --cpe "cpe:2.3:a:*:wordpress:*" "is_remote:true"
-
-# Combine CPE with other filters
-vulnx search --cpe "cpe:2.3:a:apache:tomcat:*" --severity critical,high
+# Filter by product or vendor (matches the affected_products fields)
+vulnx search --product apache,nginx "cve_created_at:2024"
+vulnx search --vendor microsoft,oracle "severity:critical"
+vulnx search --vendor apache --severity critical,high
 ```
 
 ### Status and Age Filtering
 
 ```bash
 # Vulnerability status filtering
-vulnx search --vstatus confirmed "severity:critical"
-vulnx search --vstatus new "cve_created_at:2024"
-vulnx search --vstatus modified "is_kev:true"
+vulnx search --vuln-status confirmed "severity:critical"
+vulnx search --vuln-status new "cve_created_at:2024"
+vulnx search --vuln-status modified "is_kev:true"
 
 # Age-based filtering with operators
 vulnx search --vuln-age "<7" "severity:critical"     # Last week
 vulnx search --vuln-age ">365" "is_poc:true"         # Older than a year
 vulnx search --vuln-age "30" "is_template:true"      # Exactly 30 days
-vulnx search --vuln-age "<30" --kev-only             # Recent KEV vulns
+vulnx search --vuln-age "<30" --kev                  # Recent KEV vulns
 ```
 
 ### Advanced Search Options
@@ -250,16 +237,15 @@ vulnx search --sort-asc cve_created_at "is_kev:true"
 ```bash
 # Multi-dimensional filtering
 vulnx search --product apache,nginx --severity critical,high --vuln-age "<30"
-vulnx search --vendor microsoft,oracle --exclude-severity low --kev-only
-vulnx search --cpe "cpe:2.3:a:*:*:*" --exclude-product apache,tomcat --remote-exploit
+vulnx search --vendor microsoft,oracle --severity critical,high --kev
+vulnx search --severity critical --remote-exploit --poc
 
 # Complex filtering combinations
 vulnx search \
   --product apache,nginx,mysql \
-  --exclude-vendor microsoft,oracle \
   --severity critical,high \
   --vuln-age "<14" \
-  --kev-only \
+  --kev \
   --template
 ```
 
@@ -394,8 +380,8 @@ vulnx search "cve_created_at:$DATE" --json --output "vulns_$DATE.json"
 vulnx search "affected_products.product:docker" --json --silent | \
   jq '.count' | xargs -I {} echo "Found {} Docker vulnerabilities"
 
-# Baseline security checks
-vulnx search "(apache || nginx) && severity:critical" --count-only
+# Baseline security checks (total match count)
+vulnx search "(apache || nginx) && severity:critical" --json --silent | jq '.total'
 ```
 
 ### Security Monitoring Integration

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,5 @@
 [default.extend-words]
 # from external goflags package
 Allowd = "Allowd"
+# shell variable name in USAGE.md examples
+criticals = "criticals"

--- a/cmd/vulnx/clis/search.go
+++ b/cmd/vulnx/clis/search.go
@@ -611,28 +611,6 @@ func init() { // Register flags and add command to rootCmd
 	searchCmd.Flags().StringSliceVar(&filterVendor, "vendor", nil, "filter by vendor (comma-separated)")
 	searchCmd.Flags().StringSliceVarP(&filterSeverity, "severity", "s", nil, "filter by severity (comma-separated)")
 
-	// NOTE: The following filters are disabled because they don't work with the search API:
-	// - exclude-product: NOT operator not supported
-	// - exclude-vendor: NOT operator not supported
-	// - exclude-severity: NOT operator not supported
-	// - cpe: CPE field not available in search API
-	// - assignee: Field exists in API but search queries don't return results
-	// - cwe: weaknesses.cwe_id field doesn't return results in search queries
-	//
-	// Working filters have been verified against the /v2/vulnerability/filters endpoint and tested.
-
-	/*
-		searchCmd.Flags().StringSliceVar(&filterExcludeProduct, "exclude-product", nil, "Exclude products (comma-separated)")
-		searchCmd.Flags().StringSliceVar(&filterExcludeVendor, "exclude-vendor", nil, "Exclude vendors (comma-separated)")
-		searchCmd.Flags().StringSliceVar(&filterExcludeSeverity, "exclude-severity", nil, "Exclude severities (comma-separated)")
-		searchCmd.Flags().StringSliceVarP(&filterAssignee, "assignee", "a", nil, "Filter by assignee (comma-separated)")
-
-		// Single value filters
-		searchCmd.Flags().StringVarP(&filterCPE, "cpe", "c", "", "Filter by CPE string")
-	*/
-	// NOTE: Assignee filter commented out as search queries don't return results even though field exists in API
-	// searchCmd.Flags().StringSliceVarP(&filterAssignee, "assignee", "a", nil, "Filter by assignee (comma-separated)")
-
 	searchCmd.Flags().StringVar(&filterVulnStatus, "vuln-status", "", "filter by vulnerability status (new, confirmed, unconfirmed, modified, rejected, unknown)")
 	searchCmd.Flags().StringVarP(&filterVulnAge, "vuln-age", "a", "", "filter by vulnerability age (supports <, >, exact: e.g., '5', '<10', '>30')")
 
@@ -656,9 +634,6 @@ func init() { // Register flags and add command to rootCmd
 	searchCmd.Flags().StringVar(&filterCvssScore, "cvss-score", "", "filter by cvss score (supports <, >, <=, >=, exact: e.g., '7.5', '>8.0', '<=6.0')")
 	searchCmd.Flags().StringVar(&filterEpssScore, "epss-score", "", "filter by epss score (supports <, >, <=, >=, exact: e.g., '0.5', '>0.8', '<=0.3')")
 
-	// Additional filters
-	// NOTE: CWE filter disabled - weaknesses.cwe_id field doesn't return results in search queries
-	// searchCmd.Flags().StringSliceVar(&filterCwe, "cwe", nil, "Filter by CWE ID (comma-separated)")
 	searchCmd.Flags().StringSliceVar(&filterTags, "tags", nil, "filter by tags (comma-separated)")
 	searchCmd.Flags().StringSliceVar(&filterVulnType, "vuln-type", nil, "filter by vulnerability type (e.g., sql_injection, reflected_xss, stored_xss, command_injection)")
 


### PR DESCRIPTION
Fixes #476. Removes `--cpe` and other filters the search API doesn't support from docs and code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated advanced search examples to use current filtering options for product, vendor, vulnerability status, age, and KEV queries.
  * Reworked combined filter examples to show clearer multi-flag usage.
  * Changed the baseline security check example to use JSON output with `jq` for counting matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->