### PR TITLE
chore: prepare v2.0.2 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ GOFLAGS := -v
 LDFLAGS := -s -w
 
 # Version from source; override with: make build VERSION=v2.0.3
-VERSION ?= $(shell grep '^\s*Version = ' cmd/vulnx/clis/version.go | sed -E 's/.*"([^"]+)".*/\1/')
+VERSION ?= $(shell awk -F'"' '/Version = /{print $$2; exit}' cmd/vulnx/clis/version.go)
+ifeq ($(VERSION),)
+VERSION := dev
+endif
 VERSION_LDFLAG := -X github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis.Version=$(VERSION)
 
 ifneq ($(shell go env GOOS),darwin)

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GOFLAGS := -v
 # This should be disabled if the binary uses pprof
 LDFLAGS := -s -w
 
-# Determine the version from git tags (falls back to "dev" if not in a tag)
-VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+# Version from source; override with: make build VERSION=v2.0.3
+VERSION ?= $(shell grep '^\s*Version = ' cmd/vulnx/clis/version.go | sed -E 's/.*"([^"]+)".*/\1/')
 VERSION_LDFLAG := -X github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis.Version=$(VERSION)
 
 ifneq ($(shell go env GOOS),darwin)

--- a/cmd/integration-test/main.go
+++ b/cmd/integration-test/main.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
-	"github.com/projectdiscovery/vulnx/v2/pkg/testutils"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/vulnx/v2/pkg/testutils"
 )
 
 var (

--- a/cmd/vulnx/clis/analyze.go
+++ b/cmd/vulnx/clis/analyze.go
@@ -8,8 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/jedib0t/go-pretty/v6/table"

--- a/cmd/vulnx/clis/auth.go
+++ b/cmd/vulnx/clis/auth.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/projectdiscovery/vulnx/v2/pkg/tools/filters"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/utils/auth/pdcp"
+	"github.com/projectdiscovery/vulnx/v2/pkg/tools/filters"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -66,14 +66,8 @@ func runAuthCommand() {
 
 		// Temporarily set the API key in environment for validation
 		originalEnvKey := os.Getenv("PDCP_API_KEY")
-		os.Setenv("PDCP_API_KEY", nonInteractiveAPIKey)
-		defer func() {
-			if originalEnvKey != "" {
-				os.Setenv("PDCP_API_KEY", originalEnvKey)
-			} else {
-				os.Unsetenv("PDCP_API_KEY")
-			}
-		}()
+		setPDCPAPIKeyEnv(nonInteractiveAPIKey)
+		defer restorePDCPAPIKeyEnv(originalEnvKey)
 
 		// Validate the API key with the server
 		if !validateCurrentAPIKey(nonInteractiveAPIKey, "provided API key") {
@@ -272,14 +266,8 @@ func runAuthCommand() {
 
 	// Temporarily set the API key in environment for validation
 	originalEnvKey := os.Getenv("PDCP_API_KEY")
-	os.Setenv("PDCP_API_KEY", apiKey)
-	defer func() {
-		if originalEnvKey != "" {
-			os.Setenv("PDCP_API_KEY", originalEnvKey)
-		} else {
-			os.Unsetenv("PDCP_API_KEY")
-		}
-	}()
+	setPDCPAPIKeyEnv(apiKey)
+	defer restorePDCPAPIKeyEnv(originalEnvKey)
 
 	// Initialize the vulnx client to test the API key
 	err = ensureVulnxClientInitialized(nil)
@@ -326,8 +314,8 @@ func validateCurrentAPIKey(apiKey, source string) bool {
 	// Temporarily set the API key in environment if it's not already set
 	originalEnvKey := os.Getenv("PDCP_API_KEY")
 	if originalEnvKey == "" {
-		os.Setenv("PDCP_API_KEY", apiKey)
-		defer os.Unsetenv("PDCP_API_KEY")
+		setPDCPAPIKeyEnv(apiKey)
+		defer restorePDCPAPIKeyEnv("")
 	}
 
 	// Initialize the vulnx client (same method as healthcheck)
@@ -352,6 +340,24 @@ func validateCurrentAPIKey(apiKey, source string) bool {
 	}
 
 	return true
+}
+
+func setPDCPAPIKeyEnv(key string) {
+	if err := os.Setenv("PDCP_API_KEY", key); err != nil {
+		gologger.Warning().Msgf("Failed to set PDCP_API_KEY: %s", err)
+	}
+}
+
+func restorePDCPAPIKeyEnv(original string) {
+	var err error
+	if original != "" {
+		err = os.Setenv("PDCP_API_KEY", original)
+	} else {
+		err = os.Unsetenv("PDCP_API_KEY")
+	}
+	if err != nil {
+		gologger.Warning().Msgf("Failed to restore PDCP_API_KEY: %s", err)
+	}
 }
 
 func init() {

--- a/cmd/vulnx/clis/common.go
+++ b/cmd/vulnx/clis/common.go
@@ -20,18 +20,18 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/levels"
 	retryablehttp "github.com/projectdiscovery/retryablehttp-go"
+	"github.com/projectdiscovery/vulnx/v2"
 
 	"github.com/mark3labs/mcp-go/server"
+	fileutil "github.com/projectdiscovery/utils/file"
+	updateutils "github.com/projectdiscovery/utils/update"
 	"github.com/projectdiscovery/vulnx/v2/pkg/tools"
 	"github.com/projectdiscovery/vulnx/v2/pkg/tools/analyze"
 	"github.com/projectdiscovery/vulnx/v2/pkg/tools/id"
 	"github.com/projectdiscovery/vulnx/v2/pkg/tools/renderer"
-	fileutil "github.com/projectdiscovery/utils/file"
-	updateutils "github.com/projectdiscovery/utils/update"
 )
 
 //go:embed banner.txt
@@ -127,7 +127,7 @@ var (
 			}
 			s := server.NewMCPServer(
 				"ProjectDiscovery vulnerability.sh (vulnx)",
-				"1.0.0",
+				strings.TrimPrefix(Version, "v"),
 				server.WithToolCapabilities(false),
 				server.WithRecovery(),
 			)

--- a/cmd/vulnx/clis/completion.go
+++ b/cmd/vulnx/clis/completion.go
@@ -264,7 +264,7 @@ func installBashCompletion(userOnly bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to create completion file: %w", err)
 	}
-	defer file.Close()
+	defer closeCompletionFile(file)
 
 	// Generate completion script
 	if err := generateBashCompletionRobust(file); err != nil {
@@ -333,7 +333,7 @@ func installZshCompletion(userOnly bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to create completion file: %w", err)
 	}
-	defer file.Close()
+	defer closeCompletionFile(file)
 
 	// Generate completion script
 	if err := rootCmd.GenZshCompletion(file); err != nil {
@@ -401,7 +401,7 @@ func installFishCompletion(userOnly bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to create completion file: %w", err)
 	}
-	defer file.Close()
+	defer closeCompletionFile(file)
 
 	// Generate completion script
 	if err := rootCmd.GenFishCompletion(file, true); err != nil {
@@ -441,8 +441,8 @@ func installPowerShellCompletion(userOnly bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to create temp file: %w", err)
 	}
-	defer os.Remove(tempFile.Name())
-	defer tempFile.Close()
+	defer removeTempFile(tempFile.Name())
+	defer closeCompletionFile(tempFile)
 
 	if err := rootCmd.GenPowerShellCompletion(tempFile); err != nil {
 		return fmt.Errorf("failed to generate PowerShell completion: %w", err)
@@ -473,7 +473,7 @@ func installPowerShellCompletion(userOnly bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to open profile file: %w", err)
 	}
-	defer file.Close()
+	defer closeCompletionFile(file)
 
 	if _, err := file.WriteString("\n# vulnx completion\n"); err != nil {
 		return fmt.Errorf("failed to write completion header: %w", err)
@@ -504,6 +504,18 @@ func confirmOverwrite(path string) bool {
 
 func isWindows() bool {
 	return os.PathSeparator == '\\'
+}
+
+func closeCompletionFile(file *os.File) {
+	if err := file.Close(); err != nil {
+		gologger.Warning().Msgf("Failed to close completion file: %s", err)
+	}
+}
+
+func removeTempFile(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		gologger.Warning().Msgf("Failed to remove temp file: %s", err)
+	}
 }
 
 func init() {

--- a/cmd/vulnx/clis/healthcheck.go
+++ b/cmd/vulnx/clis/healthcheck.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/projectdiscovery/vulnx/v2/pkg/tools/filters"
-	"github.com/projectdiscovery/gologger"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/vulnx/clis/id.go
+++ b/cmd/vulnx/clis/id.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/projectdiscovery/gologger"
 	fileutil "github.com/projectdiscovery/utils/file"
+	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/projectdiscovery/vulnx/v2/pkg/tools/id"

--- a/cmd/vulnx/clis/search.go
+++ b/cmd/vulnx/clis/search.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/vulnx/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/projectdiscovery/vulnx/v2/pkg/tools/renderer"

--- a/cmd/vulnx/clis/version.go
+++ b/cmd/vulnx/clis/version.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// Version can be set via ldflags during build
-	Version = "v1.0.0"
+	Version = "v2.0.2"
 
 	disableUpdateCheck bool
 
@@ -41,15 +41,15 @@ vulnx version --disable-update-check
 )
 
 func showVersion() {
-	gologger.Info().Msgf("Current vulnx version %s", Version)
-
 	if disableUpdateCheck {
+		gologger.Info().Msgf("Current vulnx version %s", Version)
 		return
 	}
 
 	// Check for latest version using PDTM API
 	latestVersion, err := updateutils.GetToolVersionCallback("vulnx", Version)()
 	if err != nil {
+		gologger.Info().Msgf("Current vulnx version %s", Version)
 		if verbose || debug {
 			gologger.Error().Msgf("vulnx version check failed: %v", err.Error())
 		}

--- a/cmd/vulnx/main.go
+++ b/cmd/vulnx/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis"
 	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/vulnx/v2/cmd/vulnx/clis"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/shirou/gopsutil/v3 v3.23.7 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/sorairolake/lzip-go v0.3.5 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -292,10 +292,12 @@ github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d h1:hrujxIzL1woJ7
 github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d/go.mod h1:uugorj2VCxiV1x+LzaIdVa9b4S4qGAcH6cbhh4qVxOU=
 github.com/shirou/gopsutil/v3 v3.23.7 h1:C+fHO8hfIppoJ1WdsVm1RoI0RwXoNdfTK7yWXV0wVj4=
 github.com/shirou/gopsutil/v3 v3.23.7/go.mod h1:c4gnmoRC0hQuaLqvxnx1//VXQ0Ms/X9UnJF8pddY5z4=
-github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
-github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
+github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
+github.com/shoenig/go-m1cpu v0.2.1/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
+github.com/shoenig/test v1.7.0/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/pkg/tools/renderer/colors.go
+++ b/pkg/tools/renderer/colors.go
@@ -211,12 +211,14 @@ func (c *ColorConfig) ColorBoolean(checkmark string) string {
 		return checkmark
 	}
 
-	if checkmark == "✔" {
+	switch checkmark {
+	case "✔":
 		return c.Colorize(checkmark, c.Success)
-	} else if checkmark == "✘" {
+	case "✘":
 		return c.Colorize(checkmark, c.Error)
+	default:
+		return checkmark
 	}
-	return checkmark
 }
 
 // ColorExposure colors exposure values with appropriate colors

--- a/pkg/tools/renderer/types.go
+++ b/pkg/tools/renderer/types.go
@@ -13,29 +13,29 @@ type LayoutLine struct {
 
 // Entry represents a vulnerability entry with all fields needed for rendering
 type Entry struct {
-	DocID            string                `json:"doc_id"`
-	Name             string                `json:"name"`
-	Severity         string                `json:"severity"`
-	Author           []string              `json:"author"`
-	AgeInDays        int                   `json:"age_in_days"`
-	EpssScore        float64               `json:"epss_score"`
-	CvssScore        float64               `json:"cvss_score"`
+	DocID            string               `json:"doc_id"`
+	Name             string               `json:"name"`
+	Severity         string               `json:"severity"`
+	Author           []string             `json:"author"`
+	AgeInDays        int                  `json:"age_in_days"`
+	EpssScore        float64              `json:"epss_score"`
+	CvssScore        float64              `json:"cvss_score"`
 	Exposure         *vulnx.VulnExposure  `json:"exposure"`
 	AffectedProducts []*vulnx.ProductInfo `json:"affected_products"`
-	IsPatchAvailable bool                  `json:"is_patch_available"`
-	PocCount         int                   `json:"poc_count"`
-	IsKev            bool                  `json:"is_kev"`
+	IsPatchAvailable bool                 `json:"is_patch_available"`
+	PocCount         int                  `json:"poc_count"`
+	IsKev            bool                 `json:"is_kev"`
 	Kev              []*vulnx.KevInfo     `json:"kev"`
-	IsTemplate       bool                  `json:"is_template"`
+	IsTemplate       bool                 `json:"is_template"`
 	H1               *vulnx.H1Stats       `json:"h1"`
-	Tags             []string              `json:"tags"`
+	Tags             []string             `json:"tags"`
 	Pocs             []*vulnx.POC         `json:"pocs"`
 	Citations        []*vulnx.Citation    `json:"citations"`
-	Description      string                `json:"description"`
-	Impact           string                `json:"impact"`
-	Remediation      string                `json:"remediation"`
-	TemplateURI      string                `json:"template_uri"`
-	TemplateRaw      string                `json:"template_raw"`
+	Description      string               `json:"description"`
+	Impact           string               `json:"impact"`
+	Remediation      string               `json:"remediation"`
+	TemplateURI      string               `json:"template_uri"`
+	TemplateRaw      string               `json:"template_raw"`
 }
 
 // FromVulnerability converts a vulnx.Vulnerability to an Entry


### PR DESCRIPTION
## Summary
- Bump default version to `v2.0.2` and read build version from `version.go` in the Makefile
- Fix duplicate version line in `vulnx version` output
- Wire MCP server version to the shared `Version` variable
- Upgrade `go-m1cpu` to v0.2.1 to fix SIGSEGV on newer Apple Silicon (Darwin 25.x / M5)
- Resolve errcheck and staticcheck lint findings in auth, completion, and renderer code

## Test plan
- [x] `make fmt && make vet && make lint` pass
- [x] `make build && ./vulnx version` prints a single version line
- [x] `./vulnx version` no longer segfaults on Apple Silicon


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the displayed application version to **v2.0.2** and improved version reporting consistency (including build/startup and MCP server version output).
  * Version checks now honor the “disable update check” option with cleaner control flow.

* **Bug Fixes**
  * Improved API key setup/login behavior by using safer temporary environment handling and clearer warning messages if environment changes fail.
  * Hardened shell completion installation cleanup to log close/remove issues instead of silently ignoring them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->